### PR TITLE
feat: Add GPIO/I2S pin definitions for ESP32-S3 (M5Stack Core S3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,15 +11,21 @@ AcidBox is an ESP32-based audio synthesizer project that implements a combinatio
 - ESP32 or ESP32-S3 with at least 4MB PSRAM (ESP32 WROVER module recommended)
 - External DAC like PCM5102 (highly recommended for quality)
 - Compatible with both regular ESP32 and ESP32-S3 variants
+- **M5Stack Core S3 supported** with specific pin configurations
 
 ## Development Environment
 
 This is an Arduino IDE project (tested with v1.8.20) for ESP32/ESP32-S3 microcontrollers.
 
 ### Board Configuration (Arduino IDE)
-- Board: ESP32 Dev Module (or ESP32S3 Dev Module for S3)
+- Board: ESP32 Dev Module (or ESP32S3 Dev Module for S3, or M5Stack Core S3 for M5Stack boards)
 - Partition scheme: No OTA (1MB APP/ 3MB SPIFFS)
 - PSRAM: enabled (or appropriate PSRAM type)
+
+### PlatformIO Configuration
+- `pio run -e esp32`: Build for ESP32
+- `pio run -e esp32s3`: Build for generic ESP32-S3
+- `pio run -e m5stack-cores3`: Build for M5Stack Core S3 (includes M5STACK_CORES3 define)
 
 ### Dependencies
 - MIDI Library: https://github.com/FortySevenEffects/arduino_midi_library

--- a/config.h
+++ b/config.h
@@ -28,11 +28,22 @@
 #define MIDITX_PIN      15      // this pin will be used for output (not implemented yet) when MIDI_VIA_SERIAL2 defined
 
 #define POT_NUM 3
+
+// Pin definitions for different ESP32 variants and boards
 #if defined(CONFIG_IDF_TARGET_ESP32S3)
-#define I2S_BCLK_PIN    5       // I2S BIT CLOCK pin (BCL BCK CLK)
-#define I2S_WCLK_PIN    7       // I2S WORD CLOCK pin (WCK WCL LCK)
-#define I2S_DOUT_PIN    6       // to I2S DATA IN pin (DIN D DAT)
-const uint8_t POT_PINS[POT_NUM] = {15, 16, 17};
+  #if defined(ARDUINO_M5STACK_CORES3) || defined(M5STACK_CORES3)
+    // M5Stack Core S3 specific pin configuration
+    #define I2S_BCLK_PIN    12      // I2S BIT CLOCK pin (BCL BCK CLK)
+    #define I2S_WCLK_PIN    0       // I2S WORD CLOCK pin (WCK WCL LCK)
+    #define I2S_DOUT_PIN    2       // to I2S DATA IN pin (DIN D DAT)
+    const uint8_t POT_PINS[POT_NUM] = {1, 3, 8};  // Available GPIO pins on M5Stack Core S3
+  #else
+    // Generic ESP32-S3 pin configuration
+    #define I2S_BCLK_PIN    5       // I2S BIT CLOCK pin (BCL BCK CLK)
+    #define I2S_WCLK_PIN    7       // I2S WORD CLOCK pin (WCK WCL LCK)
+    #define I2S_DOUT_PIN    6       // to I2S DATA IN pin (DIN D DAT)
+    const uint8_t POT_PINS[POT_NUM] = {15, 16, 17};
+  #endif
 #elif defined(CONFIG_IDF_TARGET_ESP32)
 #define I2S_BCLK_PIN    5       // I2S BIT CLOCK pin (BCL BCK CLK)
 #define I2S_WCLK_PIN    19      // I2S WORD CLOCK pin (WCK WCL LCK)

--- a/platformio.ini
+++ b/platformio.ini
@@ -32,3 +32,17 @@ build_flags =
 lib_deps = 
     throwtheswitch/Unity@^2.5.2
 monitor_speed = 115200
+
+[env:m5stack-cores3]
+platform = espressif32
+board = m5stack-cores3
+framework = arduino
+build_flags = 
+    -D UNIT_TEST
+    -D TABLE_SIZE=1024
+    -D PI=3.14159265358979323846
+    -D CONFIG_IDF_TARGET_ESP32S3
+    -D M5STACK_CORES3
+lib_deps = 
+    throwtheswitch/Unity@^2.5.2
+monitor_speed = 115200


### PR DESCRIPTION
Add M5Stack Core S3 support with specific GPIO/I2S pin definitions

- Add conditional compilation for M5Stack Core S3 pin configuration
- Add PlatformIO environment for M5Stack Core S3
- Update documentation with usage instructions

Closes #2

Generated with [Claude Code](https://claude.ai/code)