### PR TITLE
feat: add env:core_s3 configuration for M5Stack Core S3

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -46,3 +46,17 @@ build_flags =
 lib_deps = 
     throwtheswitch/Unity@^2.5.2
 monitor_speed = 115200
+
+[env:core_s3]
+platform = espressif32
+board = m5stack-cores3
+framework = arduino
+build_flags = 
+    -D UNIT_TEST
+    -D TABLE_SIZE=1024
+    -D PI=3.14159265358979323846
+    -D CONFIG_IDF_TARGET_ESP32S3
+    -D M5STACK_CORES3
+lib_deps = 
+    throwtheswitch/Unity@^2.5.2
+monitor_speed = 115200

--- a/test/test_compile_core_s3.cpp
+++ b/test/test_compile_core_s3.cpp
@@ -1,0 +1,42 @@
+#include <unity.h>
+
+// Dummy test for Core S3 compilation verification
+// This test always passes to ensure build pipeline works
+void test_core_s3_compilation() {
+    TEST_ASSERT_TRUE(true);
+}
+
+void test_core_s3_defines() {
+    // Verify that M5STACK_CORES3 is defined for this environment
+    #ifdef M5STACK_CORES3
+    TEST_ASSERT_TRUE(true);
+    #else
+    TEST_FAIL_MESSAGE("M5STACK_CORES3 should be defined for core_s3 environment");
+    #endif
+}
+
+#ifdef ARDUINO
+void setup() {
+    delay(2000); // Give time for serial monitor to open
+    
+    UNITY_BEGIN();
+    
+    RUN_TEST(test_core_s3_compilation);
+    RUN_TEST(test_core_s3_defines);
+    
+    UNITY_END();
+}
+
+void loop() {
+    // Empty loop for Arduino
+}
+#else
+int main() {
+    UNITY_BEGIN();
+    
+    RUN_TEST(test_core_s3_compilation);
+    RUN_TEST(test_core_s3_defines);
+    
+    return UNITY_END();
+}
+#endif


### PR DESCRIPTION
Add new `env:core_s3` to `platformio.ini` for M5Stack Core S3

- Add env:core_s3 environment to platformio.ini as alias for m5stack-cores3
- Create test_compile_core_s3.cpp with dummy tests that always pass
- Ensures `pio run -e core_s3` compiles successfully in CI/CD

Fixes #5

Generated with [Claude Code](https://claude.ai/code)